### PR TITLE
fix: macro hid

### DIFF
--- a/lib/KeyboardioHID/src/HID.cpp
+++ b/lib/KeyboardioHID/src/HID.cpp
@@ -63,6 +63,7 @@ int HID_::SendReport_(uint8_t id, const void *data, int len) {
 	return ret2;
   return ret + ret2;
 #endif
+  while(!usb_hid.ready()){tight_loop_contents();}
   bool b = usb_hid.sendReport(id, data, len);
   return b;
 


### PR DESCRIPTION
If the program sends 2 hid reports in less than 1ms it will lose one of them. This way we will wait until the first is sent
