### PR TITLE
Fix: macros.memory

### DIFF
--- a/lib/Kaleidoscope/src/kaleidoscope/plugin/DynamicMacros.cpp
+++ b/lib/Kaleidoscope/src/kaleidoscope/plugin/DynamicMacros.cpp
@@ -283,7 +283,7 @@ namespace kaleidoscope
 
     EventHandlerResult DynamicMacros::onFocusEvent(const char *command)
     {
-      if (::Focus.handleHelp(command, PSTR("macros.map\nmacros.trigger")))
+      if (::Focus.handleHelp(command, PSTR("macros.map\nmacros.trigger\nmacros.memory")))
         return EventHandlerResult::OK;
 
       if (strncmp_P(command, PSTR("macros."), 7) != 0)
@@ -321,6 +321,14 @@ namespace kaleidoscope
         uint8_t id = 0;
         ::Focus.read(id);
         play(id);
+      }
+
+      if (strcmp_P(command + 7, PSTR("memory")) == 0)
+      {
+        if (::Focus.isEOL())
+        {
+          ::Focus.send(storage_size_);
+        }
       }
 
       return EventHandlerResult::EVENT_CONSUMED;


### PR DESCRIPTION
new Focus endpoint for macros that gives back the amount of reserved memory